### PR TITLE
Add pytest marker for skipping tests that require a GPU

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,17 +7,22 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+    parser.addoption("--rungpu", action="store_true", default=False, help="run gpu tests")
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "gpu: mark test as gpu required to run")
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        # --runslow given in cli: do not skip slow tests
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+    if not config.getoption("--runslow"):
+        skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
+    if not config.getoption("--rungpu"):
+        skip_gpu = pytest.mark.skip(reason="need --rungpu option to run")
+        for item in items:
+            if "gpu" in item.keywords:
+                item.add_marker(skip_gpu)


### PR DESCRIPTION
Our build manager is not provisioned with GPUs, so we need a way to disable tests requiring GPUs. This PR adds a test decorator for skipping those tests (extending the example found [here](https://docs.pytest.org/en/latest/example/simple.html)).

To add a test that will only be run when pytest is invoked with the `--rungpu` option, do this:
```
@pytest.mark.gpu
def test_...
```

To add a test that will only be run when pytest is invoked with the `--runslow` option, do this:
```
@pytest.mark.slow
def test_...
```

This PR was tested by adding dummy decorators to existing tests and manually checking test logs.