### PR TITLE
Remove CircleCI context used by Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,7 @@ jobs:
 workflows:
   build:
     jobs:
-      - test:
-         context: jiant_context
+      - test
       - docs-build
       - docs-deploy:
           requires:


### PR DESCRIPTION
Codecov does not require upload token (stored in CircleCI context) for public projects.